### PR TITLE
Drop redundant description in tool schemas

### DIFF
--- a/blue_lugia/managers/llm.py
+++ b/blue_lugia/managers/llm.py
@@ -648,7 +648,13 @@ class LanguageModelManager(Manager):
                 if tool_config_strict:
                     tool.model_config["extra"] = "forbid"
 
-                parameters = self._rm_titles(tool.model_json_schema())
+                # Get the JSON schema of the tool
+                tool_json_schema = tool.model_json_schema()
+                # Remove the redundant description
+                if "description" in tool_json_schema:
+                    tool_json_schema.pop("description")
+                # Remove the redundant titles
+                parameters = self._rm_titles(tool_json_schema)
 
                 options["tools"].append(
                     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blue-lugia"
-version = "0.25.2"
+version = "0.26.0"
 description = "Unique SDK Wrapper"
 authors = ["Sofiane TALEB <sofiane.ext@unique.ch>"]
 readme = "README.md"


### PR DESCRIPTION
Using `BaseModel.model_json_schema` creates a duplicate of the `BaseModel` description under the `"description"` key.  The tool description should instead be supplied alongside the function description for OpenAI. Other libraries such as instructor (see [here](https://github.com/jxnl/instructor/blob/main/instructor/function_calls.py#L47)) drop these as redundant fields.